### PR TITLE
Add global-hover-minor-mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following example uses **all available** configurations above, you can custo
         hover-screenshot-prefix "my-prefix-"
         hover-observatory-uri "http://my-custom-host:50300"
         hover-clear-buffer-on-hot-restart t))
-  (hover-minor-mode 1))
+  (hover-global-minor-mode t))
 ```
 
 _Thanks to [flutter.el](https://github.com/amake/flutter.el) which inspired this project._

--- a/hover.el
+++ b/hover.el
@@ -294,5 +294,15 @@ args."
   :keymap hover-minor-mode-map
   :group 'hover)
 
+(defun hover-turn-on-hover-minor-mode ()
+  "Turn on `hover-minor-mode'."
+    (hover-minor-mode t))
+
+;;;###autoload
+(define-globalized-minor-mode hover-global-minor-mode
+  hover-minor-mode hover-turn-on-hover-minor-mode
+  :group 'hover
+  :require 'hover-minor-mode)
+
 (provide 'hover)
 ;;; hover.el ends here


### PR DESCRIPTION
Sorry, we need add (global-hover-minor-mode) for achieve the same effect as https://github.com/ericdallo/hover.el/issues/12#issuecomment-1024964211

hover-minor-mode is needed too, that permit use can disable it in mode hook even global-hover-minor-mode enabled.